### PR TITLE
Add env helper tests and fix moderation tests

### DIFF
--- a/__tests__/utils/env-helpers.test.ts
+++ b/__tests__/utils/env-helpers.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { getAppUrl } from '@/utils/env-helpers'
+
+const ORIGINAL_ENV = { ...process.env }
+
+const originalWindow = global.window
+
+afterEach(() => {
+  Object.assign(process.env, ORIGINAL_ENV)
+  if (originalWindow) {
+    // restore original window if it existed
+    global.window = originalWindow
+  } else {
+    // delete the window added during tests
+    // @ts-ignore
+    delete global.window
+  }
+})
+
+describe('getAppUrl', () => {
+  it('returns window location origin on client side', () => {
+    // @ts-ignore
+    global.window = { location: { origin: 'https://client.example.com' } }
+    const url = getAppUrl()
+    expect(url).toBe('https://client.example.com')
+  })
+
+  it('uses NEXT_PUBLIC_SITE_URL on server side', () => {
+    // @ts-ignore
+    delete global.window
+    process.env.NEXT_PUBLIC_SITE_URL = 'https://site.example.com'
+    const url = getAppUrl()
+    expect(url).toBe('https://site.example.com')
+  })
+
+  it('falls back to localhost when no env vars are set', () => {
+    // @ts-ignore
+    delete global.window
+    delete process.env.NEXT_PUBLIC_SITE_URL
+    delete process.env.VERCEL_URL
+    delete process.env.NEXTAUTH_URL
+    const url = getAppUrl()
+    expect(url).toBe('http://localhost:3000')
+  })
+})

--- a/__tests__/utils/moderation.test.ts
+++ b/__tests__/utils/moderation.test.ts
@@ -19,25 +19,26 @@ describe('moderateContent', () => {
   it('should allow appropriate content', async () => {
     const result = await moderateContent('これは適切なコンテンツです')
     expect(result.isAppropriate).toBe(true)
-    expect(result.scores).toBeDefined()
+    expect(result.reason).toBe('')
   })
 
   it('should flag inappropriate content with keywords', async () => {
     const result = await moderateContent('バカ野郎')
     expect(result.isAppropriate).toBe(false)
-    expect(result.reason).toContain('Inappropriate language detected')
+    expect(result.reason).toContain('不適切な表現')
   })
 
   it('should handle empty content', async () => {
     const result = await moderateContent('')
-    expect(result.isAppropriate).toBe(true)
+    expect(result.isAppropriate).toBe(false)
+    expect(result.reason).toBe('回答が短すぎます')
   })
 
   it('should handle very long content', async () => {
     const longContent = 'あ'.repeat(10001)
     const result = await moderateContent(longContent)
     expect(result.isAppropriate).toBe(false)
-    expect(result.reason).toContain('Content too long')
+    expect(result.reason).toBe('回答が長すぎます')
   })
 
   it('should use Perspective API when available', async () => {
@@ -53,7 +54,10 @@ describe('moderateContent', () => {
       })
     )
 
+    process.env.PERSPECTIVE_API_KEY = 'test-key'
     const result = await moderateContent('test content')
-    expect(result.scores?.toxicity).toBe(0.8)
+    expect(result.isAppropriate).toBe(false)
+    expect(result.confidence).toBeCloseTo(0.8)
+    expect(result.severity).toBe('medium')
   })
 })


### PR DESCRIPTION
## Summary
- add unit tests for env helper `getAppUrl`
- update moderation tests to match current implementation

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f9c8153108329a41da208764c0fa6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added tests for URL utility function, covering client-side, server-side, and fallback scenarios.
  - Refined moderation tests to check for specific reasons, language localization, and enhanced Perspective API integration with confidence and severity assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->